### PR TITLE
fix absolute URL to articles

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -34,7 +34,7 @@
     <section>
         <h2>
             Latest Articles
-            <a class="section-button" href="/articles">View all</a>
+            <a class="section-button" href="{{ relURL "/posts" }}">View all</a>
         </h2>
         <div class="posts">
             {{ range $pages.Pages }}


### PR DESCRIPTION
At least in my setup I had to fix the template a bit to make it work. Unless I am missing something, this could be a general fix.

My setup:

1. My `config.toml` has a base URL with `https://example.com/blog/`
2. I only have content in the `posts` folder, no other pages

Thus the current default templates generates a link to `https://example.com/articles/` which for me is a 404. Afaict there is also no `/blog/articles/`, but there is `/blog/posts/`. So I am assuming a typo here :)

PS: thanks for the theme!