### PR TITLE
colorScheme options support

### DIFF
--- a/assets/sass/base/_dark.scss
+++ b/assets/sass/base/_dark.scss
@@ -6,7 +6,7 @@
     :root:not([data-user-color-scheme]) {
         --h1-color: white;
         --font-color: #b3b9c5;
-        --heading-color: #ffd479;
+        --heading-color: #ffffff;
         --dark-font-color: #ced4da;
         --background: #1f2022;
         --medium-font-color: #dee2e6;
@@ -30,7 +30,7 @@
 [data-user-color-scheme='dark'] {
     --h1-color: white;
     --font-color: #b3b9c5;
-    --heading-color: #ffd479;
+    --heading-color: #ffffff;
     --dark-font-color: #ced4da;
     --background: #1f2022;
     --medium-font-color: #dee2e6;

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -8,18 +8,10 @@
             {{ end }}
             <div class="bio-social">
                 {{ range $name, $path := $.Param "socialOptions" }}
-                {{ if (and $path (ne $name "email")) }}
-                <a href="{{ $path | safeURL }}" target="_blank" rel="noreferrer" title="{{ $name }}"
-                    aria-label="{{ $name }}">
-                    {{ partial (print "svgs/social/" $name ".svg") (dict "width" 25 "height" 25) }}
-                </a>
-                {{ end }}
-                {{ if (and $path (eq $name "email")) }}
-                <a href="mailto:{{ $path | safeURL }}" target="_blank" rel="noreferrer" title="{{ $path }}"
-                    aria-label="{{ $name }}">
-                    {{ partial (print "svgs/social/" $name ".svg") (dict "width" 25 "height" 25) }}
-                </a>
-                {{ end }}
+                    <a href="{{ $path | safeURL }}" target="_blank" rel="noreferrer" title="{{ $name }}"
+                        aria-label="{{ $name }}">
+                        {{ partial (print "svgs/social/" $name ".svg") (dict "width" 25 "height" 25) }}
+                    </a>
                 {{ end }}
             </div>
         </div>

--- a/layouts/partials/head/colorScheme.html
+++ b/layouts/partials/head/colorScheme.html
@@ -1,5 +1,5 @@
 {{- $defaultColorScheme := default "auto" .Site.Params.colorScheme.default -}}
-{{- if not (default false .Site.Params.colorScheme.toggle) -}}
+{{- if not (default true .Site.Params.colorScheme.toggle) -}}
     {{/* If toggle is disabled, force default scheme */}}
     <script>
         (function() {

--- a/layouts/partials/head/colorScheme.html
+++ b/layouts/partials/head/colorScheme.html
@@ -1,3 +1,24 @@
+{{- $defaultColorScheme := default "auto" .Site.Params.colorScheme.default -}}
+{{- if not (default false .Site.Params.colorScheme.toggle) -}}
+    {{/* If toggle is disabled, force default scheme */}}
+    <script>
+        (function() {
+            const colorSchemeKey = 'ThemeColorScheme';
+            localStorage.setItem(colorSchemeKey, "{{ $defaultColorScheme }}");
+        })();
+    </script>
+{{- else -}}
+    {{/* Otherwise set to default scheme only if no preference is set by user */}}
+    <script>
+        (function() {
+            const colorSchemeKey = 'ThemeColorScheme';
+            if(!localStorage.getItem(colorSchemeKey)){
+                localStorage.setItem(colorSchemeKey, "{{ $defaultColorScheme }}");
+            }
+        })();
+    </script>
+{{- end -}}
+
 <script>
     (function() {
         const colorSchemeKey = 'ThemeColorScheme';

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,10 +18,12 @@
                 {{ range .Site.Menus.header }}
                 <a href="{{ .URL | relURL }}"{{ if eq .URL $.RelPermalink }} aria-current="page"{{ end }}>{{ .Pre }}{{ .Name }}{{ .Post }}</a>
                 {{ end }}
-                <button id="dark-mode-button">
-                  {{ (resources.Get "icons/light.svg").Content | safeHTML }}
-                  {{ (resources.Get "icons/dark.svg").Content | safeHTML }}
-                </button>
+                {{ if (default false .Site.Params.colorScheme.toggle) }}
+                    <button id="dark-mode-button">
+                    {{ (resources.Get "icons/light.svg").Content | safeHTML }}
+                    {{ (resources.Get "icons/dark.svg").Content | safeHTML }}
+                    </button>
+                {{ end }}
             </div>
             </div>
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,7 +18,7 @@
                 {{ range .Site.Menus.header }}
                 <a href="{{ .URL | relURL }}"{{ if eq .URL $.RelPermalink }} aria-current="page"{{ end }}>{{ .Pre }}{{ .Name }}{{ .Post }}</a>
                 {{ end }}
-                {{ if (default false .Site.Params.colorScheme.toggle) }}
+                {{ if (default true .Site.Params.colorScheme.toggle) }}
                     <button id="dark-mode-button">
                     {{ (resources.Get "icons/light.svg").Content | safeHTML }}
                     {{ (resources.Get "icons/dark.svg").Content | safeHTML }}


### PR DESCRIPTION
Added colorScheme configuration from __hugo-theme-stack__.

The default colorScheme can now be configured in `config.yml` with:
``` yml
params:
  colorScheme:
    toggle: false # true as default
    default: light # light | dark | auto (auto as default)
```