### PR TITLE
feat: Twitter card support

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -15,7 +15,25 @@
     <meta name="twitter:title" content="{{with.Title}}{{.}} | {{end}}{{.Site.Title}}" />
     <meta name="application-name" content="{{with.Title}}{{.}} | {{end}}{{.Site.Title}}" />
 
-    {{ template "_internal/twitter_cards.html" . }}
+    {{- with $.Params.images -}}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
+    {{ else -}}
+    {{- $images := $.Resources.ByType "image" -}}
+    {{- $featured := $images.GetMatch "*feature*" -}}
+    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+    {{- with $featured -}}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:image" content="{{ $featured.Permalink }}"/>
+    {{- else -}}
+    {{- with $.Site.Params.images -}}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
+    {{ else -}}
+    <meta name="twitter:card" content="summary"/>
+    {{- end -}}
+    {{- end -}}
+    {{- end }}
 
     <meta name="description" content="{{ if .Description }}{{.Description}}{{ else }}{{.Site.Params.siteDesc}}{{end}}" />
     <meta name="twitter:description" content="{{ if .Description }}{{.Description}} {{ else }}{{.Site.Params.siteDesc}}{{end}}"/>

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -15,6 +15,7 @@
     <meta name="twitter:title" content="{{with.Title}}{{.}} | {{end}}{{.Site.Title}}" />
     <meta name="application-name" content="{{with.Title}}{{.}} | {{end}}{{.Site.Title}}" />
 
+    {{ template "_internal/twitter_cards.html" . }}
 
     <meta name="description" content="{{ if .Description }}{{.Description}}{{ else }}{{.Site.Params.siteDesc}}{{end}}" />
     <meta name="twitter:description" content="{{ if .Description }}{{.Description}} {{ else }}{{.Site.Params.siteDesc}}{{end}}"/>


### PR DESCRIPTION
Add twitter card `<meata>`  support. All the logic was ripped from the internal [template][1] provided by Hugo.

```yaml
---
title: article name
date: 2021-04-21T01:25:00-04:00
images:
- images/img1.png
---
```

This supports homepage cards as well:

```yaml
params:
  images:
  - images/8yRnin.png
```

Before:
![how-wtf-without-twitter-card](https://user-images.githubusercontent.com/22714707/146703632-60d1be31-30d9-48fb-a006-79194be3c9c2.PNG)

After:
![how-wtf-with-twitter-card](https://user-images.githubusercontent.com/22714707/146703634-6128eaf3-a772-47de-9406-f598c4cfea3f.PNG)

[1]: https://gohugo.io/templates/internal/#twitter-cards