### PR TITLE
colorScheme options support

### DIFF
--- a/exampleSite/config.example.toml
+++ b/exampleSite/config.example.toml
@@ -21,6 +21,14 @@ disqusShortname = "https-hugo-tania-netlify-app"
   siteDesc = "Hugo is Absurdly Fast!"
   author = "Hugo Tania"
 
+  [params.colorScheme]
+    # Enable toggle colorScheme
+    # Default to true
+    toggle = true
+    # Default colorScheme
+    # Default to auto
+    default = auto
+
   # Limit how many categories filter show above search input.
   # Default to 5
   maxCategoryToShow = 10

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -21,6 +21,13 @@ params:
   siteDesc: "Hugo is Absurdly Fast!"
   author: "Hugo Tania"
 
+  colorScheme:
+    # Enable toggle colorScheme
+    # Default to true
+    toggle: true
+    # Default colorScheme
+    # Default to auto
+    default: auto
 
   # Limit how many categories filter show above search input.
   # Default to 5

--- a/layouts/partials/head/colorScheme.html
+++ b/layouts/partials/head/colorScheme.html
@@ -1,5 +1,5 @@
 {{- $defaultColorScheme := default "auto" .Site.Params.colorScheme.default -}}
-{{- if not (default false .Site.Params.colorScheme.toggle) -}}
+{{- if not (default true .Site.Params.colorScheme.toggle) -}}
     {{/* If toggle is disabled, force default scheme */}}
     <script>
         (function() {

--- a/layouts/partials/head/colorScheme.html
+++ b/layouts/partials/head/colorScheme.html
@@ -1,3 +1,24 @@
+{{- $defaultColorScheme := default "auto" .Site.Params.colorScheme.default -}}
+{{- if not (default false .Site.Params.colorScheme.toggle) -}}
+    {{/* If toggle is disabled, force default scheme */}}
+    <script>
+        (function() {
+            const colorSchemeKey = 'ThemeColorScheme';
+            localStorage.setItem(colorSchemeKey, "{{ $defaultColorScheme }}");
+        })();
+    </script>
+{{- else -}}
+    {{/* Otherwise set to default scheme only if no preference is set by user */}}
+    <script>
+        (function() {
+            const colorSchemeKey = 'ThemeColorScheme';
+            if(!localStorage.getItem(colorSchemeKey)){
+                localStorage.setItem(colorSchemeKey, "{{ $defaultColorScheme }}");
+            }
+        })();
+    </script>
+{{- end -}}
+
 <script>
     (function() {
         const colorSchemeKey = 'ThemeColorScheme';

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,10 +18,12 @@
                 {{ range .Site.Menus.header }}
                 <a href="{{ .URL | relURL }}"{{ if eq .URL $.RelPermalink }} aria-current="page"{{ end }}>{{ .Pre }}{{ .Name }}{{ .Post }}</a>
                 {{ end }}
-                <button id="dark-mode-button">
-                  {{ (resources.Get "icons/light.svg").Content | safeHTML }}
-                  {{ (resources.Get "icons/dark.svg").Content | safeHTML }}
-                </button>
+                {{ if (default false .Site.Params.colorScheme.toggle) }}
+                    <button id="dark-mode-button">
+                    {{ (resources.Get "icons/light.svg").Content | safeHTML }}
+                    {{ (resources.Get "icons/dark.svg").Content | safeHTML }}
+                    </button>
+                {{ end }}
             </div>
             </div>
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,7 +18,7 @@
                 {{ range .Site.Menus.header }}
                 <a href="{{ .URL | relURL }}"{{ if eq .URL $.RelPermalink }} aria-current="page"{{ end }}>{{ .Pre }}{{ .Name }}{{ .Post }}</a>
                 {{ end }}
-                {{ if (default false .Site.Params.colorScheme.toggle) }}
+                {{ if (default true .Site.Params.colorScheme.toggle) }}
                     <button id="dark-mode-button">
                     {{ (resources.Get "icons/light.svg").Content | safeHTML }}
                     {{ (resources.Get "icons/dark.svg").Content | safeHTML }}


### PR DESCRIPTION
Added colorScheme configuration options from hugo-theme-stack.

The default colorScheme can now be configured in config.yml with:

``` yaml
params:
  colorScheme:
    toggle: false # true as default
    default: light # light | dark | auto (auto as default)
```