### PR TITLE
Change enableFootnotes to respect page frontmatter

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -36,6 +36,6 @@
     {{- $opts := dict "minify" hugo.IsProduction -}}
     {{ $features := resources.Get "ts/features.ts" | js.Build $opts | fingerprint }}
     <script defer src="{{ $features.RelPermalink }}" 
-    data-enable-footnotes="{{ .Site.Params.enableFootnotes | default true }}"
+    data-enable-footnotes="{{ .Params.enableFootnotes | default true }}"
     ></script>
 </footer>


### PR DESCRIPTION
The current behavior of floating footnotes (set by `enableFootnotes`) is to use the site-level setting—changing this parameter in a post does not have an effect.

This commit changes that, i.e. `enableFootnotes` respects changing the setting in a page's frontmatter.